### PR TITLE
default for QSS3KeyPrefix should be quickstart-sitecore-xp/

### DIFF
--- a/templates/sitecore-xp-functions.template.yaml
+++ b/templates/sitecore-xp-functions.template.yaml
@@ -18,7 +18,7 @@ Parameters:
     AllowedPattern: ^[0-9a-zA-Z-/.]*$
     ConstraintDescription: Quick Start key prefix can include numbers, lowercase letters,
       uppercase letters, hyphens (-), dots(.) and forward slash (/).
-    Default: quickstart-amazon-eks/
+    Default: quickstart-sitecore-xp/
     Description: S3 key prefix for the Quick Start assets. Quick Start key prefix
       can include numbers, lowercase letters, uppercase letters, hyphens (-), dots(.) and
       forward slash (/).


### PR DESCRIPTION
*Description of changes:*
for sitecore-xp, the default value for QSS3KeyPrefix should be quickstart-sitecore-xp/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
