### PR TITLE
fix issue: the password should be specified during initialling RDS, o…

### DIFF
--- a/scripts/install/sc-install-resources.ps1
+++ b/scripts/install/sc-install-resources.ps1
@@ -342,6 +342,7 @@ switch ($Role) {
                         XConnectCert             = $($parameters.xConnectCertificateThumbPrint)
                         SqlDbPrefix              = $($parameters.SCPrefix)
                         SqlServer                = $($parameters.SQLServer)
+                        SitecoreAdminPassword    = $($secrets.SitecoreAdminPassword)
                         SqlAdminUser             = $($secrets.SqlAdminUser)
                         SqlAdminPassword         = $($secrets.SqlAdminPassword)
                         SqlCoreUser              = $($secrets.SqlCoreUser)


### PR DESCRIPTION
…therwise it will generate a random one.

*Issue #, if available:*

*Description of changes:*
the admin password is first set while initialing RDS, if we didn't specify the password at this step, the CM will generate a random password for the sitecore admin and lead to failure while we are trying to login with the password in Secret Manager.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
