### PR TITLE
Updated SQLEngineVersion with latest supported value

### DIFF
--- a/templates/sitecore-xp-existing-vpc.template.yaml
+++ b/templates/sitecore-xp-existing-vpc.template.yaml
@@ -577,6 +577,7 @@ Parameters:
     Type: String
   SQLEngineVersion:
     AllowedValues:
+      - 14.00.3381.3.v1
       - 14.00.3223.3.v1
       - 14.00.3192.2.v1
       - 14.00.3049.1.v1
@@ -584,7 +585,7 @@ Parameters:
       - 14.00.3015.40.v1
       - 14.00.1000.169.v1
     ConstraintDescription: 'Must select a MSSQL database engine version.'
-    Default: 14.00.3223.3.v1
+    Default: 14.00.3381.3.v1
     Description: MSSQL database engine version.
     Type: String
   SQLAlwaysOn:

--- a/templates/sitecore-xp-master.template.yaml
+++ b/templates/sitecore-xp-master.template.yaml
@@ -652,6 +652,7 @@ Parameters:
     Type: String
   SQLEngineVersion:
     AllowedValues:
+      - 14.00.3381.3.v1
       - 14.00.3223.3.v1
       - 14.00.3192.2.v1
       - 14.00.3049.1.v1
@@ -659,7 +660,7 @@ Parameters:
       - 14.00.3015.40.v1
       - 14.00.1000.169.v1
     ConstraintDescription: Must select a MSSQL database engine version.
-    Default: 14.00.3223.3.v1
+    Default: 14.00.3381.3.v1
     Description: MSSQL database engine version.
     Type: String
   SQLAlwaysOn:
@@ -764,7 +765,7 @@ Resources:
     Properties:
       TemplateURL: 
         !Sub
-          - 'https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-aws-vpc/templates/aws-vpc.template'
+          - 'https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-aws-vpc/templates/aws-vpc.template.yaml'
           - S3Region: !If [UsingDefaultBucket, !Ref 'AWS::Region', !Ref QSS3BucketRegion]
             S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
       Parameters:


### PR DESCRIPTION
*Issue #, if available:*
RDSStack creation is failing, due to sqlserver version incompatibility.
*Description of changes:*
Changed supported sql server versions in CloudFormation templates.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
